### PR TITLE
BH2024 - MCP server embedded in resolver API

### DIFF
--- a/webservices/pom.xml
+++ b/webservices/pom.xml
@@ -14,7 +14,7 @@
 
 
   <properties>
-    <spring.boot.version>3.1.5</spring.boot.version>
+    <spring.boot.version>3.2.3</spring.boot.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.release>17</maven.compiler.release>

--- a/webservices/resolver/pom.xml
+++ b/webservices/resolver/pom.xml
@@ -28,15 +28,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>1.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.identifiers.cloud</groupId>
             <artifactId>libapi</artifactId>
@@ -45,6 +47,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/webservices/resolver/src/main/java/org/identifiers/cloud/ws/resolver/configuration/McpConfiguration.java
+++ b/webservices/resolver/src/main/java/org/identifiers/cloud/ws/resolver/configuration/McpConfiguration.java
@@ -1,0 +1,85 @@
+package org.identifiers.cloud.ws.resolver.configuration;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.*;
+import org.identifiers.cloud.ws.resolver.services.mcp.CurieResolutionMcpTool;
+import org.identifiers.cloud.ws.resolver.services.mcp.UrlConversionMcpTool;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class McpConfiguration {
+    @Bean
+    public ToolCallbackProvider resolverMcpTools(
+            final UrlConversionMcpTool urlConversionMcpTool,
+            final CurieResolutionMcpTool curieResolutionMcpTool
+    ) {
+        return MethodToolCallbackProvider.builder()
+                .toolObjects(urlConversionMcpTool, curieResolutionMcpTool)
+                .build();
+    }
+
+    @Bean
+    public List<McpServerFeatures.SyncPromptSpecification> curieResolutionPrompt() {
+            return List.of(
+                resolveAllCurieUrlsPrompt(),
+                resolveBestCurieUrlPrompt(),
+                convertUrlToIdorgUriPrompt()
+        );
+    }
+
+    private McpServerFeatures.SyncPromptSpecification resolveBestCurieUrlPrompt() {
+        var arguments = List.of(
+                new PromptArgument("curie", "identifiers.org CURIE or compact identifier to resolve", true)
+        );
+        var prompt = new Prompt("resolve-best-curie-url",
+                "Find best valid provider URLs for an identifiers.org CURIE",
+                arguments);
+
+        return new McpServerFeatures.SyncPromptSpecification(prompt,
+                (exchange, getPromptRequest) -> {
+                    String curieArgument = (String) getPromptRequest.arguments().get("curie");
+                    var userMessage = new PromptMessage(Role.USER, new TextContent("Please the best valid provider URL for CURIE '"+curieArgument+"'"));
+                    return new GetPromptResult("Best provider URL", List.of(userMessage));
+                }
+        );
+    }
+
+    private McpServerFeatures.SyncPromptSpecification resolveAllCurieUrlsPrompt() {
+        var arguments = List.of(
+                new PromptArgument("curie", "identifiers.org CURIE or compact identifier to resolve", true)
+        );
+        var prompt = new Prompt("resolve-all-curie-urls",
+                "Find all valid provider URLs for an identifiers.org CURIE",
+                arguments);
+
+        return new McpServerFeatures.SyncPromptSpecification(prompt,
+                (exchange, getPromptRequest) -> {
+                    String curieArgument = (String) getPromptRequest.arguments().get("curie");
+                    var userMessage = new PromptMessage(Role.USER, new TextContent("Please list valid provider URLs for CURIE '"+curieArgument+"'"));
+                    return new GetPromptResult("List of provider URLs", List.of(userMessage));
+                }
+        );
+    }
+
+    private McpServerFeatures.SyncPromptSpecification convertUrlToIdorgUriPrompt() {
+        var arguments = List.of(
+                new PromptArgument("url", "Provider URL", true)
+        );
+        var prompt = new Prompt("convert-url-to-idorg-uri",
+                "Convert URL to identifiers.org URI",
+                arguments);
+
+        return new McpServerFeatures.SyncPromptSpecification(prompt,
+                (exchange, getPromptRequest) -> {
+                    String curieArgument = (String) getPromptRequest.arguments().get("curie");
+                    var userMessage = new PromptMessage(Role.USER, new TextContent("Please convert the URL '"+curieArgument+"' to an identifiers.org URI"));
+                    return new GetPromptResult("Identifiers.org URI that references the URL given", List.of(userMessage));
+                }
+        );
+    }
+}

--- a/webservices/resolver/src/main/java/org/identifiers/cloud/ws/resolver/services/mcp/CurieResolutionMcpTool.java
+++ b/webservices/resolver/src/main/java/org/identifiers/cloud/ws/resolver/services/mcp/CurieResolutionMcpTool.java
@@ -1,0 +1,46 @@
+package org.identifiers.cloud.ws.resolver.services.mcp;
+
+import lombok.RequiredArgsConstructor;
+import org.identifiers.cloud.commons.messages.models.ResolvedResource;
+import org.identifiers.cloud.ws.resolver.api.models.ResolverApiModel;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import static java.util.Comparator.comparing;
+
+@Service
+@RequiredArgsConstructor
+public class CurieResolutionMcpTool {
+    final ResolverApiModel resolverApiModel;
+
+    @Tool(description = "Get URLs resolved from curie or compact identifier")
+    public Collection<String> resolve(@ToolParam(description = "Curie or compact identifier") String curie) {
+        var resp = resolverApiModel.resolveRawCompactId(curie);
+        if (resp.getHttpStatus() == HttpStatus.OK) {
+            return resp.getPayload().getResolvedResources().stream()
+                    .map(ResolvedResource::getCompactIdentifierResolvedUrl)
+                    .toList();
+        } else {
+            return List.of();
+        }
+    }
+
+    @Tool(description = "Get best URLs resolved from curie or compact identifier")
+    public String resolveBest(@ToolParam(description = "Curie or compact identifier") String curie) {
+        var resp = resolverApiModel.resolveRawCompactId(curie);
+        if (resp.getHttpStatus() == HttpStatus.OK) {
+            return resp.getPayload().getResolvedResources().stream()
+                    .max(comparing(rr -> rr.getRecommendation().getRecommendationIndex()))
+                    .map(ResolvedResource::getCompactIdentifierResolvedUrl)
+                    .orElse(null);
+        } else {
+            return null;
+        }
+    }
+}

--- a/webservices/resolver/src/main/java/org/identifiers/cloud/ws/resolver/services/mcp/UrlConversionMcpTool.java
+++ b/webservices/resolver/src/main/java/org/identifiers/cloud/ws/resolver/services/mcp/UrlConversionMcpTool.java
@@ -1,0 +1,59 @@
+package org.identifiers.cloud.ws.resolver.services.mcp;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.identifiers.cloud.commons.messages.requests.resolver.ReverseResolutionRequestPayload;
+import org.identifiers.cloud.commons.messages.responses.resolver.ReverseResolutionMatch;
+import org.identifiers.cloud.ws.resolver.services.reverseresolution.ReverseResolutionService;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UrlConversionMcpTool {
+    private final ReverseResolutionService rrService;
+
+    @Tool(description = "Get identifiers.org URI for URL")
+    public String convert(
+            @ToolParam(description = "URL to be converted")
+            String providerUrl,
+            @ToolParam(description = "Accession of object under URL", required = false)
+            String accession
+    ) {
+        log.debug("Get identifiers.org URI for {} (accession {})", providerUrl, accession);
+        var request = getRequest(providerUrl, accession);
+        var resp = rrService.resolveBasedOnPrefix(request);
+        return resp.map(ReverseResolutionMatch::getPossibleIdorgUrl).orElse(null);
+    }
+
+
+    @Tool(description = "Get identifiers.org URIs that reference URLs similar to provider URL")
+    public Collection<String> getSimilar(
+            @ToolParam(description = "Provider URL to match with identifiers.org URIs")
+            String providerUrl,
+            @ToolParam(description = "Accession of object", required = false)
+            String accession
+    ) {
+        log.debug("Get similar identifiers.org URI for {} (accession {})", providerUrl, accession);
+        var request = getRequest(providerUrl, accession);
+        var resp = rrService.resolveBasedOnSimilarity(request);
+        return resp.stream()
+                .map(ReverseResolutionMatch::getPossibleIdorgUrl)
+                .toList();
+    }
+
+
+
+    private ReverseResolutionRequestPayload getRequest(String url, String accession) {
+        ReverseResolutionRequestPayload request = new ReverseResolutionRequestPayload();
+        request.setUrl(url);
+        if (accession != null) {
+            request.setAccession(accession);
+        }
+        return request;
+    }
+}

--- a/webservices/resolver/src/main/resources/application.properties
+++ b/webservices/resolver/src/main/resources/application.properties
@@ -58,6 +58,16 @@ org.identifiers.cloud.ws.resolver.reverse-resolution.prefix.tree-cache-duration=
 org.identifiers.cloud.ws.resolver.reverse-resolution.similarity.list-cache-duration=${WS_RESOLVER_CONFIG_RR_SIMILARITY_LIST_CACHE_DURATION:30m}
 org.identifiers.cloud.ws.resolver.reverse-resolution.similarity.max-results=${WS_RESOLVER_CONFIG_RR_SIMILARITY_MAX_RESULTS:5}
 
+# MCP
+spring.ai.mcp.server.enabled=true
+spring.ai.mcp.server.name=idorg-resolver-mcp-server
+spring.ai.mcp.server.version=1.0.0
+spring.ai.mcp.server.instructions=This server provides CURIE resolution via identifiers.org
+spring.ai.mcp.server.capabilities.tool=true
+spring.ai.mcp.server.capabilities.completion=false
+spring.ai.mcp.server.capabilities.prompt=true
+spring.ai.mcp.server.capabilities.resource=false
+
 ### Spring actuators
 management.endpoints.enabled-by-default=false
 management.endpoints.jmx.exposure.exclude=*

--- a/webservices/resolver/src/test/resources/application.properties
+++ b/webservices/resolver/src/test/resources/application.properties
@@ -3,7 +3,7 @@ spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 logging.level.root=WARN
 logging.level.org.identifiers.cloud.ws.resolver=WARN
-org.slf4j.simpleLogger.defaultLogLevel=warn
+
 #logging.level.org.matomo.java.tracking=DEBUG
 #logging.level.org.identifiers.cloud.ws.resolver.services.MatomoTrackingServiceTest=DEBUG
 
@@ -57,3 +57,9 @@ org.identifiers.cloud.ws.resolver.namespaceresolver.institution.home.url=${WS_RE
 org.identifiers.cloud.ws.resolver.namespaceresolver.institution.description=${WS_RESOLVER_CONFIG_NAMESPACE_RESOLVER_INSTITUTION_DESCRIPTION:Identifiers.org Central Registry}
 org.identifiers.cloud.ws.resolver.namespaceresolver.institution.name=${WS_RESOLVER_CONFIG_NAMESPACE_RESOLVER_INSTITUTION_NAME:EMBL-EBI}
 org.identifiers.cloud.ws.resolver.namespaceresolver.recommendation.explanation=${WS_RESOLVER_CONFIG_NAMESPACE_RESOLVER_RECOMMENDATION_EXPLANATION:Namespace resolution to identifiers.org Central Registry}
+
+
+spring.ai.mcp.server.capabilities.tool=false
+spring.ai.mcp.server.capabilities.completion=false
+spring.ai.mcp.server.capabilities.prompt=false
+spring.ai.mcp.server.capabilities.resource=false


### PR DESCRIPTION
This PR adds MCP server functionality to the identifiers.org resolver service. Four tools are defined:
- Two for resolving curies 
  - One resolves the best provider URL, and 
  - The other resolves all valid provider URLs
- Two for converting URLs into identifiers.org URIs
  - One for exact matches, and another for similarity matches.

Please find more information on what "tools" and "prompts" are in the [specification of MCP concepts](https://modelcontextprotocol.io/docs/learn/server-concepts#core-server-features).

The MCP server endpoint is found at `/sse`. [In this version of Spring AI, only SSE connections are supported; HTTP Streaming isn't](https://docs.spring.io/spring-ai/reference/1.1-SNAPSHOT/api/mcp/mcp-streamable-http-server-boot-starter-docs.html). You can test this functionality via the [MCP inspector tool](https://www.npmjs.com/package/@modelcontextprotocol/inspector). You can also use your preferred AI app, like [Claude](https://claude.ai/download) or [Cursor](https://cursor.com/downloads).